### PR TITLE
Add Wellbit API key admin utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Chase Payment Platform
+
+This repository hosts the Chase P2P payment platform. See `SETUP.md` for
+development environment instructions.
+
+## Wellbit API Keys
+
+Admin endpoints allow viewing and regenerating the API keys for the Wellbit
+merchant. Details are documented in [docs/wellbit-keys.md](docs/wellbit-keys.md).

--- a/backend/scripts/seed-dev.ts
+++ b/backend/scripts/seed-dev.ts
@@ -48,7 +48,20 @@ async function seedDevelopment() {
     })
     console.log('✓ Created test merchant')
 
-    // 4. Create payment methods
+    // 4. Create Wellbit merchant with API keys
+    await db.merchant.upsert({
+      where: { name: 'Wellbit' },
+      update: {},
+      create: {
+        name: 'Wellbit',
+        token: randomBytes(32).toString('hex'),
+        apiKeyPublic: randomBytes(16).toString('hex'),
+        apiKeyPrivate: randomBytes(32).toString('hex'),
+      }
+    })
+    console.log('✓ Created Wellbit merchant')
+
+    // 5. Create payment methods
     const methods = [
       {
         code: 'sber_c2c',
@@ -109,7 +122,7 @@ async function seedDevelopment() {
     }
     console.log('✓ Created payment methods')
 
-    // 5. Create KKK setting
+    // 6. Create KKK setting
     await db.systemConfig.upsert({
       where: { key: 'kkk_percent' },
       update: {},
@@ -120,7 +133,7 @@ async function seedDevelopment() {
     })
     console.log('✓ Created KKK setting (5%)')
 
-    // 6. Create services
+    // 7. Create services
     const services = [
       { name: 'ExpiredTransactionWatcher', displayName: 'Expired Transaction Watcher', description: 'Watches for expired transactions' },
       { name: 'MerchantEmulator', displayName: 'Merchant Emulator', description: 'Emulates merchant transactions' },

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -38,6 +38,7 @@ import processorRoutes from "@/routes/admin/processor";
 import deviceEmulatorRoutes from "@/routes/admin/device-emulator";
 import metricsRoutes from "@/routes/admin/metrics";
 import payoutEmulatorRoutes from "@/routes/admin/payout-emulator";
+import adminMerchantsRoutes from "@/routes/admin/merchants";
 import { adminPayoutsRoutes } from "@/routes/admin/payouts";
 import { telegramSettingsRoutes } from "@/routes/admin/telegram-settings";
 import { adminWithdrawalsRoutes } from "@/routes/admin/withdrawals";
@@ -97,6 +98,7 @@ export default (app: Elysia) =>
     /* ───────────────── вложенные группы ───────────────── */
     .group("/merchant", (a) => merchantRoutes(a))
     .group("/merchant/methods", (a) => methodsRoutes(a))
+    .use(adminMerchantsRoutes)
     .group("/transactions", (a) => transactionsRoutes(a))
     .group("/ip-whitelist", (a) => ipWhitelistRoutes(a))
     .group("/balance-topups", (a) => balanceTopupRoutes(a))

--- a/backend/src/routes/admin/merchants.ts
+++ b/backend/src/routes/admin/merchants.ts
@@ -1,0 +1,63 @@
+import { Elysia, t } from 'elysia';
+import { db } from '@/db';
+import { randomBytes } from 'node:crypto';
+
+export const adminMerchantsRoutes = new Elysia({ prefix: '/merchants' })
+  .get(
+    '/wellbit/keys',
+    async ({ error }) => {
+      const merchant = await db.merchant.findFirst({ where: { name: 'Wellbit' } });
+      if (!merchant) return error(404, { error: 'Wellbit merchant not found' });
+      return {
+        apiKeyPublic: merchant.apiKeyPublic,
+        apiKeyPrivate: merchant.apiKeyPrivate,
+      };
+    },
+    {
+      tags: ['admin'],
+      detail: { summary: 'Get Wellbit API keys' },
+      headers: t.Object({ 'x-admin-key': t.String() }),
+      response: {
+        200: t.Object({
+          apiKeyPublic: t.Nullable(t.String()),
+          apiKeyPrivate: t.Nullable(t.String()),
+        }),
+        404: t.Object({ error: t.String() }),
+      },
+    }
+  )
+  .post(
+    '/wellbit/regenerate',
+    async () => {
+      const apiKeyPublic = randomBytes(16).toString('hex');
+      const apiKeyPrivate = randomBytes(32).toString('hex');
+      const merchant = await db.merchant.upsert({
+        where: { name: 'Wellbit' },
+        update: { apiKeyPublic, apiKeyPrivate },
+        create: {
+          name: 'Wellbit',
+          token: randomBytes(32).toString('hex'),
+          apiKeyPublic,
+          apiKeyPrivate,
+        },
+      });
+      return {
+        apiKeyPublic: merchant.apiKeyPublic,
+        apiKeyPrivate: merchant.apiKeyPrivate,
+      };
+    },
+    {
+      tags: ['admin'],
+      detail: { summary: 'Regenerate Wellbit API keys' },
+      headers: t.Object({ 'x-admin-key': t.String() }),
+      response: {
+        200: t.Object({
+          apiKeyPublic: t.String(),
+          apiKeyPrivate: t.String(),
+        }),
+      },
+    }
+  );
+
+export default adminMerchantsRoutes;
+

--- a/docs/wellbit-keys.md
+++ b/docs/wellbit-keys.md
@@ -1,0 +1,23 @@
+# Wellbit API Keys
+
+This guide explains how to manage the API keys used for the Wellbit integration.
+
+## View Current Keys
+
+```bash
+curl -H "x-admin-key: <ADMIN_TOKEN>" \
+  http://localhost:3000/api/admin/merchants/wellbit/keys
+```
+
+The response contains `apiKeyPublic` and `apiKeyPrivate`.
+
+## Regenerate Keys
+
+Generate a new pair of keys (the Wellbit merchant will be created if missing):
+
+```bash
+curl -X POST -H "x-admin-key: <ADMIN_TOKEN>" \
+  http://localhost:3000/api/admin/merchants/wellbit/regenerate
+```
+
+Update your Wellbit integration with the returned values.

--- a/frontend/app/admin/wellbit-keys/page.tsx
+++ b/frontend/app/admin/wellbit-keys/page.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ProtectedRoute } from '@/components/auth/protected-route'
+import { AuthLayout } from '@/components/layouts/auth-layout'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { RefreshCw } from 'lucide-react'
+import { adminApi } from '@/services/api'
+import { toast } from 'sonner'
+
+interface Keys {
+  apiKeyPublic: string | null
+  apiKeyPrivate: string | null
+}
+
+export default function WellbitKeysPage() {
+  const [keys, setKeys] = useState<Keys | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [regenerating, setRegenerating] = useState(false)
+
+  const fetchKeys = async () => {
+    setLoading(true)
+    try {
+      const data = await adminApi.getWellbitKeys()
+      setKeys(data)
+    } catch {
+      toast.error('Не удалось получить ключи')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchKeys()
+  }, [])
+
+  const regenerate = async () => {
+    setRegenerating(true)
+    try {
+      const data = await adminApi.regenerateWellbitKeys()
+      setKeys(data)
+      toast.success('Ключи обновлены')
+    } catch {
+      toast.error('Не удалось обновить ключи')
+    } finally {
+      setRegenerating(false)
+    }
+  }
+
+  if (loading || !keys) {
+    return (
+      <ProtectedRoute variant="admin">
+        <AuthLayout variant="admin">
+          <div className="flex items-center justify-center min-h-[200px]">
+            <RefreshCw className="h-6 w-6 animate-spin text-gray-400" />
+          </div>
+        </AuthLayout>
+      </ProtectedRoute>
+    )
+  }
+
+  return (
+    <ProtectedRoute variant="admin">
+      <AuthLayout variant="admin">
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold text-gray-900">Wellbit API Keys</h1>
+          <Card>
+            <CardHeader>
+              <CardTitle>Current Keys</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <span className="font-medium">Public:</span>
+                <code className="ml-2 break-all bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+                  {keys.apiKeyPublic || '—'}
+                </code>
+              </div>
+              <div>
+                <span className="font-medium">Private:</span>
+                <code className="ml-2 break-all bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+                  {keys.apiKeyPrivate || '—'}
+                </code>
+              </div>
+              <Button onClick={regenerate} disabled={regenerating}>
+                {regenerating && <RefreshCw className="h-4 w-4 animate-spin mr-2" />}
+                Regenerate
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </AuthLayout>
+    </ProtectedRoute>
+  )
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -775,6 +775,16 @@ export const adminApi = {
     const response = await adminApiInstance.post('/admin/test-tools/full-test', options)
     return response.data
   },
+
+  // Wellbit keys
+  getWellbitKeys: async () => {
+    const response = await adminApiInstance.get('/admin/merchants/wellbit/keys')
+    return response.data
+  },
+  regenerateWellbitKeys: async () => {
+    const response = await adminApiInstance.post('/admin/merchants/wellbit/regenerate')
+    return response.data
+  },
 }
 
 // Server health check


### PR DESCRIPTION
## Summary
- add admin API routes for managing Wellbit API keys
- expose Wellbit key management page in frontend
- seed script now creates Wellbit merchant with keys
- document how to view and regenerate keys
- add brief project README

## Testing
- `npx prisma validate`
- `npx tsc --noEmit` *(fails: tests outside rootDir)*
- `bun test` *(fails: database column missing)*
- `npm run build` in frontend *(hangs during build)*

------
https://chatgpt.com/codex/tasks/task_e_687a3ccc60ec8320b999dc63bb8ab023