### PR TITLE
Add Wellbit API docs page

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -249,6 +249,11 @@ const app = new Elysia({ prefix: "/api" })
   // Health check endpoint
   .get("/health", () => ({ status: "healthy", timestamp: new Date().toISOString() }))
   .get("/api/health", () => ({ status: "healthy", timestamp: new Date().toISOString() }))
+  .get("/wellbit/openapi.yaml", async ({ set }) => {
+    set.headers["content-type"] = "application/yaml";
+    const path = join(process.cwd(), "../docs/openapi-v1.6.yaml");
+    return await readFile(path);
+  })
   // ── Feature groups ────────────────────────────────────────────
   .group("/user", (app) => app.use(userRoutes))
   .group("/info", (app) => app.use(infoRoutes))

--- a/docs/wellbit-docs.md
+++ b/docs/wellbit-docs.md
@@ -1,0 +1,8 @@
+# Wellbit API Documentation
+
+The Wellbit API reference is available through the admin dashboard and can be accessed without authentication.
+
+- **Backend endpoint:** [`/wellbit/openapi.yaml`](http://localhost:3000/wellbit/openapi.yaml)
+- **Frontend page:** [`/wellbit/docs`](http://localhost:3001/wellbit/docs)
+
+The page embeds Swagger UI so you can try requests directly in the browser.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,6 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Wellbit API Docs
+Visit `/wellbit/docs` in the running frontend or use the admin sidebar link to open the documentation.

--- a/frontend/app/wellbit/docs/page.tsx
+++ b/frontend/app/wellbit/docs/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import SwaggerUI from "swagger-ui-react";
+import "swagger-ui-react/swagger-ui.css";
+
+export default function WellbitDocsPage() {
+  return (
+    <div className="p-4">
+      <SwaggerUI url="/wellbit/openapi.yaml" />
+    </div>
+  );
+}

--- a/frontend/components/navigation/sidebar.tsx
+++ b/frontend/components/navigation/sidebar.tsx
@@ -204,6 +204,11 @@ const adminNavItems: NavItem[] = [
     href: "/admin/test-tools",
     icon: TestTube,
   },
+  {
+    title: "Wellbit API",
+    href: "/wellbit/docs",
+    icon: BookOpen,
+  },
 ]
 
 const agentNavItems: NavItem[] = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,8 @@
     "recharts": "^3.0.2",
     "socket.io-client": "^4.7.2",
     "sonner": "^2.0.5",
+    "swagger-ui": "^5.27.0",
+    "swagger-ui-react": "^5.27.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",


### PR DESCRIPTION
## Summary
- expose `/wellbit/openapi.yaml` from backend
- add Swagger UI page under `/wellbit/docs`
- link Wellbit docs in admin sidebar and README
- document usage in `docs/wellbit-docs.md`

## Testing
- `npm run build` in `frontend`
- `bun test` *(fails: Prisma errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a3cf0f0288320b8f3721d01b09d4c