### PR TITLE
Change Wellbit get/status endpoints to POST

### DIFF
--- a/backend/src/routes/wellbit/index.ts
+++ b/backend/src/routes/wellbit/index.ts
@@ -43,27 +43,27 @@ export default (app: Elysia) =>
         }),
       }
     )
-    .get(
+    .post(
       '/payment/get',
-      async ({ query, wellbitMerchant, error }) => {
-        const payout = await db.payout.findUnique({ where: { id: String(query.id) } });
+      async ({ body, wellbitMerchant, error }) => {
+        const payout = await db.payout.findUnique({ where: { id: String(body.id) } });
         if (!payout || payout.merchantId !== wellbitMerchant.id) {
           return error(404, { error: 'Payment not found' });
         }
         return { payout };
       },
       {
-        query: t.Object({ id: t.String() }),
+        body: t.Object({ id: t.String() }),
       }
     )
-    .get(
+    .post(
       '/payment/status',
-      async ({ query, wellbitMerchant, error }) => {
-        const payout = await db.payout.findUnique({ where: { id: String(query.id) } });
+      async ({ body, wellbitMerchant, error }) => {
+        const payout = await db.payout.findUnique({ where: { id: String(body.id) } });
         if (!payout || payout.merchantId !== wellbitMerchant.id) {
           return error(404, { error: 'Payment not found' });
         }
         return { status: payout.status };
       },
-      { query: t.Object({ id: t.String() }) }
+      { body: t.Object({ id: t.String() }) }
     );

--- a/backend/tests/wellbit.test.ts
+++ b/backend/tests/wellbit.test.ts
@@ -69,26 +69,32 @@ describe('Wellbit routes', () => {
   });
 
   it('gets payment', async () => {
+    const body = { id: payoutId };
     const res = await app.handle(
-      new Request(`http://localhost/payment/get?id=${payoutId}`, {
-        method: 'GET',
+      new Request('http://localhost/payment/get', {
+        method: 'POST',
         headers: {
+          'content-type': 'application/json',
           'x-api-key': publicKey,
-          'x-api-token': sign(''),
+          'x-api-token': sign(body),
         },
+        body: JSON.stringify(body),
       })
     );
     expect(res.status).toBe(200);
   });
 
   it('checks payment status', async () => {
+    const body = { id: payoutId };
     const res = await app.handle(
-      new Request(`http://localhost/payment/status?id=${payoutId}`, {
-        method: 'GET',
+      new Request('http://localhost/payment/status', {
+        method: 'POST',
         headers: {
+          'content-type': 'application/json',
           'x-api-key': publicKey,
-          'x-api-token': sign(''),
+          'x-api-token': sign(body),
         },
+        body: JSON.stringify(body),
       })
     );
     expect(res.status).toBe(200);

--- a/docs/openapi-v1.6.yaml
+++ b/docs/openapi-v1.6.yaml
@@ -355,35 +355,43 @@ paths:
           description: Payment created
 
   /wellbit/payment/get:
-    get:
+    post:
       summary: Get payment details
       tags: [Wellbit]
       security:
         - ApiKeyAuth: []
         - HmacAuth: []
-      parameters:
-        - in: query
-          name: id
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
       responses:
         200:
           description: Payment details
 
   /wellbit/payment/status:
-    get:
+    post:
       summary: Get payment status
       tags: [Wellbit]
       security:
         - ApiKeyAuth: []
         - HmacAuth: []
-      parameters:
-        - in: query
-          name: id
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
       responses:
         200:
           description: Payment status


### PR DESCRIPTION
## Summary
- update wellbit payment lookup routes to use POST body
- document POST endpoints in openapi spec
- adjust tests for new POST behaviour

## Testing
- `bun test` *(fails: PrismaClientKnownRequestError)*
- `bun x tsc -p tsconfig.json --noEmit` *(errors: TS6059 files not under rootDir)*
- `npx prisma validate`

------
https://chatgpt.com/codex/tasks/task_e_687a48d005cc8320983524b2f23b3813