### PR TITLE
Fix Docker build by allowing legacy peer deps

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,9 @@ WORKDIR /app
 
 # Install dependencies
 COPY package.json ./
-RUN npm install --frozen-lockfile || npm install
+# React 19 conflicts with swagger-ui-react peer deps
+# Allow legacy peer deps to ensure install succeeds
+RUN npm install --frozen-lockfile --legacy-peer-deps || npm install --legacy-peer-deps
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
## Summary
- allow installation with `--legacy-peer-deps` in frontend Dockerfile

## Testing
- `bun test` *(fails: column `deposit` does not exist, etc.)*
- `bun x tsc --noEmit` *(fails: `rootDir` mismatch)*
- `npx prisma validate`
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_687a516ae6408320bdff9dcd24d2f6b5