### PR TITLE
Remove container wrapper from merchant API docs

### DIFF
--- a/frontend/components/merchant/api-docs/api-documentation.tsx
+++ b/frontend/components/merchant/api-docs/api-documentation.tsx
@@ -527,7 +527,7 @@ export function ApiDocumentation() {
   };
 
   return (
-    <div className="container mx-auto py-6 space-y-6">
+    <div className="py-6 space-y-6">
       {/* Header */}
       <div className="space-y-2">
         <h1 className="text-3xl font-bold">API Документация</h1>


### PR DESCRIPTION
## Summary
- widen layout in `ApiDocumentation` by dropping the `container` class

## Testing
- `npm run build` in `frontend`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687a728656688320b299c84b2b1b8f44