### PR TITLE
Fix PiggyBank icon import

### DIFF
--- a/frontend/components/navigation/mobile-menu-drawer.tsx
+++ b/frontend/components/navigation/mobile-menu-drawer.tsx
@@ -24,7 +24,8 @@ import {
   UserPlus,
   DollarSign,
   Folder,
-  TrendingUp
+  TrendingUp,
+  PiggyBank
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTraderAuth, useAdminAuth } from "@/stores/auth";


### PR DESCRIPTION
## Summary
- import `PiggyBank` icon in the mobile menu drawer

## Testing
- `bun test` *(fails: PrismaClientKnownRequestError)*
- `npm run build --foreground-scripts`

------
https://chatgpt.com/codex/tasks/task_e_688020a233b883208ec4dda98d740f58