### PR TITLE
Fix missing icon imports

### DIFF
--- a/frontend/components/navigation/mobile-menu-drawer.tsx
+++ b/frontend/components/navigation/mobile-menu-drawer.tsx
@@ -25,7 +25,14 @@ import {
   DollarSign,
   Folder,
   TrendingUp,
-  PiggyBank
+  PiggyBank,
+  Clock,
+  Send,
+  BarChart3,
+  Headphones,
+  TestTube,
+  Trash2,
+  BookOpen
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTraderAuth, useAdminAuth } from "@/stores/auth";


### PR DESCRIPTION
## Summary
- add missing Lucide icons to mobile menu drawer

## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails: several type errors)*
- `bash .gpt/run-tests.sh` *(fails: script errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880260d3a5083209f45a9cb2123bad7