### PR TITLE
Fix APK upload and download link

### DIFF
--- a/backend/src/routes/admin/app-versions.ts
+++ b/backend/src/routes/admin/app-versions.ts
@@ -103,10 +103,11 @@ export default (app: Elysia) =>
           await mkdir(join(process.cwd(), 'uploads', 'apk'), { recursive: true });
           
           // Save file to disk
-          await Bun.write(filePath, file);
-          
+          const arrayBuffer = await file.arrayBuffer();
+          await Bun.write(filePath, Buffer.from(arrayBuffer));
+
           // Get file size
-          const fileSize = file.size;
+          const fileSize = arrayBuffer.byteLength;
           
           // Set all versions to non-primary
           await db.appVersion.updateMany({

--- a/frontend/components/navigation/mobile-menu-drawer.tsx
+++ b/frontend/components/navigation/mobile-menu-drawer.tsx
@@ -565,7 +565,10 @@ export function MobileMenuDrawer({ variant, isOpen, onClose }: MobileMenuDrawerP
                     variant="outline"
                     className="w-full justify-start gap-2 text-sm text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-gray-50"
                     onClick={() => {
-                      window.open('/apk/chase.apk', '_blank');
+                      window.open(
+                        `${process.env.NEXT_PUBLIC_API_URL}/app/download-apk`,
+                        '_blank'
+                      );
                     }}
                   >
                     <Download className="h-4 w-4 text-green-600" />


### PR DESCRIPTION
## Summary
- fix admin app upload so file saves correctly
- update trader mobile menu APK download link to use API endpoint

## Testing
- `bun x tsc --noEmit` *(fails: File not under rootDir)*
- `bun test` *(fails: many tests failing)*
- `npm run build` in `frontend` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68853ac27b6883209d952b3e2fd962d5