### PR TITLE
Fix APK upload limit

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
+    client_max_body_size 100m;
 
     # Gzip compression
     gzip on;


### PR DESCRIPTION
## Summary
- configure nginx to allow larger file uploads

## Testing
- `bunx tsc --noEmit` *(fails: TS6059 files not under rootDir)*
- `npx prisma validate`
- `bun test` *(fails: various expectation errors)*
- `npm run build` in frontend


------
https://chatgpt.com/codex/tasks/task_e_6885544f80e48320956c2bd7006aa772