### PR TITLE
Add merchant request logging

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -150,6 +150,7 @@ model Merchant {
   Transaction          Transaction[]
   transactionAttempts  TransactionAttempt[]
   withdrawalDisputes   WithdrawalDispute[]
+  merchantRequestLogs  MerchantRequestLog[]
 }
 
 model Method {
@@ -992,9 +993,21 @@ model PayoutCancellationHistory {
   createdAt DateTime @default(now())
   payout    Payout   @relation(fields: [payoutId], references: [id])
   trader    User     @relation(fields: [traderId], references: [id])
-  
+
   @@index([payoutId])
   @@index([traderId])
+  @@index([createdAt])
+}
+
+model MerchantRequestLog {
+  id         String              @id @default(cuid())
+  merchantId String
+  type       MerchantRequestType
+  data       Json
+  createdAt  DateTime            @default(now())
+  merchant   Merchant            @relation(fields: [merchantId], references: [id])
+
+  @@index([merchantId])
   @@index([createdAt])
 }
 
@@ -1253,4 +1266,9 @@ enum SettleRequestStatus {
   APPROVED
   REJECTED
   COMPLETED
+}
+
+enum MerchantRequestType {
+  TRANSACTION_IN
+  PAYOUT_CREATE
 }

--- a/backend/src/api/merchant/payouts.ts
+++ b/backend/src/api/merchant/payouts.ts
@@ -2,8 +2,9 @@ import { Elysia, t } from "elysia";
 import { PayoutService } from "../../services/payout.service";
 import { payoutAccountingService } from "../../services/payout-accounting.service";
 import { db } from "../../db";
-import type { PayoutStatus } from "@prisma/client";
+import type { PayoutStatus, MerchantRequestType } from "@prisma/client";
 import { validateFileUrls } from "../../middleware/fileUploadValidation";
+import { MerchantRequestLogService } from "../../services/merchant-request-log.service";
 
 const payoutService = PayoutService.getInstance();
 
@@ -41,6 +42,13 @@ export const merchantPayoutsApi = new Elysia({ prefix: "/payouts" })
       if ("error" in merchant) {
         return merchant;
       }
+
+      // Log request for admin
+      await MerchantRequestLogService.log(
+        merchant.id,
+        MerchantRequestType.PAYOUT_CREATE,
+        body
+      );
       
       try {
         const payout = await payoutService.createPayout({

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -52,6 +52,7 @@ import bulkDeleteRoutes from "@/routes/admin/bulk-delete";
 import ideasRoutes from "@/routes/admin/ideas";
 import testRoutes from "@/routes/admin/test";
 import { settleRequestsRoutes } from "@/routes/admin/settle-requests";
+import { merchantRequestLogsRoutes } from "@/routes/admin/merchant-request-logs";
 // import { testToolsRoutes } from "@/routes/admin/test-tools";
 
 const authHeader = t.Object({ "x-admin-key": t.String() });
@@ -137,6 +138,7 @@ export default (app: Elysia) =>
     .group("/ideas", (a) => ideasRoutes(a))
     .group("/test", (a) => testRoutes(a))
     .use(settleRequestsRoutes)
+    .use(merchantRequestLogsRoutes)
     // .group("/test-tools", (a) => a.use(testToolsRoutes))
     .group("", (a) => metricsRoutes(a))
 

--- a/backend/src/routes/admin/merchant-request-logs.ts
+++ b/backend/src/routes/admin/merchant-request-logs.ts
@@ -1,0 +1,49 @@
+import { Elysia, t } from "elysia";
+import { db } from "@/db";
+import { MerchantRequestType } from "@prisma/client";
+
+export const merchantRequestLogsRoutes = new Elysia({ prefix: "/merchant-request-logs" })
+  .get("/", async ({ query }) => {
+    const page = parseInt(query.page || "1");
+    const limit = parseInt(query.limit || "50");
+    const skip = (page - 1) * limit;
+
+    const where: any = {};
+    if (query.merchantId) where.merchantId = query.merchantId;
+    if (query.type) where.type = query.type as MerchantRequestType;
+
+    const [logs, total] = await db.$transaction([
+      db.merchantRequestLog.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+        include: { merchant: { select: { id: true, name: true } } },
+      }),
+      db.merchantRequestLog.count({ where }),
+    ]);
+
+    return {
+      data: logs.map((l) => ({
+        id: l.id,
+        merchantId: l.merchantId,
+        merchantName: l.merchant.name,
+        type: l.type,
+        data: l.data,
+        createdAt: l.createdAt.toISOString(),
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }, {
+    query: t.Object({
+      page: t.Optional(t.String()),
+      limit: t.Optional(t.String()),
+      merchantId: t.Optional(t.String()),
+      type: t.Optional(t.Enum(MerchantRequestType)),
+    }),
+  });

--- a/backend/src/routes/merchant/index.ts
+++ b/backend/src/routes/merchant/index.ts
@@ -23,6 +23,8 @@ import { calculateFreezingParams } from "@/utils/freezing";
 import { rapiraService } from "@/services/rapira.service";
 import { merchantPayoutsApi } from "@/api/merchant/payouts";
 import { validateFileUpload } from "@/middleware/fileUploadValidation";
+import { MerchantRequestLogService } from "@/services/merchant-request-log.service";
+import { MerchantRequestType } from "@prisma/client";
 
 export default (app: Elysia) =>
   app
@@ -416,6 +418,13 @@ export default (app: Elysia) =>
         if (merchant.disabled) {
           return error(403, { error: "Ваш трафик временно отключен. Обратитесь к администратору." });
         }
+
+        // Log request data for admin review
+        await MerchantRequestLogService.log(
+          merchant.id,
+          MerchantRequestType.TRANSACTION_IN,
+          body
+        );
         
         // По умолчанию тип транзакции IN
         const type = body.type || TransactionType.IN;

--- a/backend/src/services/merchant-request-log.service.ts
+++ b/backend/src/services/merchant-request-log.service.ts
@@ -1,0 +1,18 @@
+import { db } from "../db";
+import { MerchantRequestType } from "@prisma/client";
+
+export class MerchantRequestLogService {
+  static async log(merchantId: string, type: MerchantRequestType, data: any) {
+    try {
+      await db.merchantRequestLog.create({
+        data: {
+          merchantId,
+          type,
+          data,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to log merchant request", error);
+    }
+  }
+}

--- a/frontend/app/admin/merchant-requests/page.tsx
+++ b/frontend/app/admin/merchant-requests/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { adminApi } from '@/services/api'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from '@/components/ui/pagination'
+import { format } from 'date-fns'
+
+interface LogItem {
+  id: string
+  merchantId: string
+  merchantName: string
+  type: string
+  data: any
+  createdAt: string
+}
+
+export default function MerchantRequestsPage() {
+  const [logs, setLogs] = useState<LogItem[]>([])
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+
+  useEffect(() => { loadLogs() }, [page])
+
+  const loadLogs = async () => {
+    try {
+      const res = await adminApi.getMerchantRequestLogs({ page, limit: 20 })
+      setLogs(res.data || [])
+      setTotalPages(res.pagination?.totalPages || 1)
+    } catch (e) {
+      console.error('Failed to load logs', e)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Merchant Requests</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Merchant</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Data</TableHead>
+                <TableHead>Date</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {logs.map(log => (
+                <TableRow key={log.id}>
+                  <TableCell>{log.id}</TableCell>
+                  <TableCell>{log.merchantName}</TableCell>
+                  <TableCell>{log.type}</TableCell>
+                  <TableCell>
+                    <pre className="whitespace-pre-wrap text-xs max-w-xs overflow-x-auto">{JSON.stringify(log.data)}</pre>
+                  </TableCell>
+                  <TableCell>{format(new Date(log.createdAt), 'yyyy-MM-dd HH:mm')}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {totalPages > 1 && (
+            <div className="mt-4">
+              <Pagination>
+                <PaginationContent>
+                  <PaginationItem>
+                    <PaginationPrevious href="#" onClick={e => { e.preventDefault(); if(page>1) setPage(page-1) }} />
+                  </PaginationItem>
+                  {[...Array(totalPages)].map((_,i)=>{const p=i+1;return(
+                    <PaginationItem key={p}>
+                      <PaginationLink href="#" onClick={e=>{e.preventDefault();setPage(p)}} isActive={p===page}>{p}</PaginationLink>
+                    </PaginationItem>)})}
+                  <PaginationItem>
+                    <PaginationNext href="#" onClick={e=>{e.preventDefault(); if(page<totalPages) setPage(page+1)}} />
+                  </PaginationItem>
+                </PaginationContent>
+              </Pagination>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -944,6 +944,10 @@ export const adminApi = {
     const response = await adminApiInstance.get(`/admin/settle-requests/merchant/${merchantId}`, { params })
     return response.data
   },
+  getMerchantRequestLogs: async (params?: { page?: number; limit?: number; merchantId?: string; type?: string }) => {
+    const response = await adminApiInstance.get('/admin/merchant-request-logs', { params })
+    return response.data
+  },
 }
 
 // Server health check


### PR DESCRIPTION
## Summary
- log merchant IN transaction and payout requests
- store logs in `MerchantRequestLog` model
- expose admin API to view logged requests
- allow frontend admin to list merchant requests

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887d6dda3f88320aa6c2e45b98062d2