### PR TITLE
Do not freeze profit during merchant transaction creation

### DIFF
--- a/backend/src/routes/merchant/index.ts
+++ b/backend/src/routes/merchant/index.ts
@@ -21,9 +21,8 @@ import { disputesRoutes } from "./disputes";
 import { dealDisputesRoutes } from "./deal-disputes";
 import { dealDisputesApiRoutes } from "./deal-disputes-api";
 import { payoutDisputesApiRoutes } from "./payout-disputes-api";
-import { calculateFreezingParams } from "@/utils/freezing";
 import { rapiraService } from "@/services/rapira.service";
-import { floorDown2 } from '@/utils/freezing';
+import { ceilUp2 } from '@/utils/freezing';
 import { merchantPayoutsApi } from "@/api/merchant/payouts";
 import { validateFileUpload } from "@/middleware/fileUploadValidation";
 import { MerchantRequestLogService } from "@/services/merchant-request-log.service";
@@ -683,10 +682,11 @@ export default (app: Elysia) =>
         console.log(`[Merchant IN] Merchant rate (saved for reference): ${merchantRate}`);
 
         // ВСЕГДА рассчитываем заморозку с курсом Рапиры с ККК
-        // Используем floorDown2 для обрезания до 2 знаков после запятой
-        const frozenUsdtAmount = floorDown2(body.amount / transactionRate);
-        const calculatedCommission = floorDown2((frozenUsdtAmount * feeInPercent) / 100);
-        const totalRequired = floorDown2(frozenUsdtAmount + calculatedCommission);
+        // Используем ceilUp2 для округления вверх до 2 знаков
+        const frozenUsdtAmount = ceilUp2(body.amount / transactionRate);
+        // Комиссию и прибыль не замораживаем при создании сделки
+        const calculatedCommission = 0;
+        const totalRequired = frozenUsdtAmount; // Замораживаем только основную сумму
 
         const freezingParams = {
           adjustedRate: transactionRate, // Use Rapira rate with KKK for freezing

--- a/backend/src/utils/freezing.ts
+++ b/backend/src/utils/freezing.ts
@@ -41,9 +41,9 @@ export function calculateAdjustedRate(
  * @returns количество USDT для заморозки (обрезано до 2 знаков)
  */
 export function calculateFrozenUsdt(amountRub: number, adjustedRate: number): number {
-  // Используем floorDown2 для обрезания до 2 знаков после запятой
-  // Например: 0.0098 -> 0.00
-  return floorDown2(amountRub / adjustedRate);
+  // Используем ceilUp2 для округления вверх до 2 знаков после запятой
+  // Например: 0.0098 -> 0.01
+  return ceilUp2(amountRub / adjustedRate);
 }
 
 /**
@@ -53,8 +53,8 @@ export function calculateFrozenUsdt(amountRub: number, adjustedRate: number): nu
  * @returns комиссия в USDT (обрезано до 2 знаков)
  */
 export function calculateCommissionUsdt(frozenUsdt: number, feeInPercent: number): number {
-  // Используем floorDown2 для обрезания до 2 знаков после запятой
-  return floorDown2(frozenUsdt * feeInPercent / 100);
+  // Используем ceilUp2 для округления вверх до 2 знаков после запятой
+  return ceilUp2((frozenUsdt * feeInPercent) / 100);
 }
 
 /**
@@ -81,8 +81,8 @@ export function calculateFreezingParams(
   const adjustedRate = calculateAdjustedRate(rateMerchant, kkkPercent, kkkOperation);
   const frozenUsdtAmount = calculateFrozenUsdt(amountRub, adjustedRate);
   const calculatedCommission = calculateCommissionUsdt(frozenUsdtAmount, feeInPercent);
-  // Обрезаем totalRequired до 2 знаков после запятой
-  const totalRequired = floorDown2(frozenUsdtAmount + calculatedCommission);
+  // Округляем totalRequired вверх до 2 знаков после запятой
+  const totalRequired = ceilUp2(frozenUsdtAmount + calculatedCommission);
 
   return {
     adjustedRate,


### PR DESCRIPTION
## Summary
- Avoid adding trader profit to frozen USDT when creating merchant IN transactions
- Round up frozen USDT amounts to the nearest cent during transaction creation

## Testing
- `bun test` *(fails: Expected status 200 but received 404, among other failures)*
- `bun run typecheck` *(fails: Script not found)*
- `npx prisma validate`


------
https://chatgpt.com/codex/tasks/task_e_6891360f91c4832084ada66eea32db2e