### PR TITLE
Validate method ID for merchant payout creation

### DIFF
--- a/backend/src/api/merchant/payouts.ts
+++ b/backend/src/api/merchant/payouts.ts
@@ -93,6 +93,7 @@ export const merchantPayoutsApi = new Elysia({ prefix: "/payouts" })
     },
     {
       body: t.Object({
+        methodId: t.String(),
         amount: t.Number({ minimum: 100 }),
         wallet: t.String({ minLength: 10 }),
         bank: t.String({ minLength: 3 }),

--- a/backend/src/services/payout.service.ts
+++ b/backend/src/services/payout.service.ts
@@ -73,7 +73,11 @@ export class PayoutService {
       throw new Error("Merchant not found");
     }
 
-    const method = await db.method.findUnique({
+    if (!methodId) {
+      throw new Error("Method ID is required");
+    }
+
+    const method = await db.method.findFirst({
       where: { id: methodId, merchantMethods: { some: { merchantId } } },
     });
 


### PR DESCRIPTION
## Summary
- require methodId in merchant payout creation request body
- validate methodId before lookup and handle missing IDs gracefully

## Testing
- `bun run typecheck` *(fails: Script not found "typecheck")*
- `npx prisma validate`
- `bun test` *(fails: PrismaClientValidationError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68934897040c8320b28151ae4dbc5ec0