### PR TITLE
feat: add payout callback system

### DIFF
--- a/backend/prisma/migrations/20250822000000_add_payout_callback_history/migration.sql
+++ b/backend/prisma/migrations/20250822000000_add_payout_callback_history/migration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "PayoutCallbackHistory" (
+    "id" TEXT NOT NULL,
+    "payoutId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "response" TEXT,
+    "statusCode" INTEGER,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PayoutCallbackHistory_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "PayoutCallbackHistory_payoutId_idx" ON "PayoutCallbackHistory"("payoutId");
+CREATE INDEX "PayoutCallbackHistory_createdAt_idx" ON "PayoutCallbackHistory"("createdAt" DESC);
+
+ALTER TABLE "PayoutCallbackHistory" ADD CONSTRAINT "PayoutCallbackHistory_payoutId_fkey" FOREIGN KEY ("payoutId") REFERENCES "Payout"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -255,6 +255,21 @@ model CallbackHistory {
   @@index([createdAt(sort: Desc)])
 }
 
+model PayoutCallbackHistory {
+  id         String   @id @default(cuid())
+  payoutId   String
+  url        String
+  payload    Json
+  response   String?
+  statusCode Int?
+  error      String?
+  createdAt  DateTime @default(now())
+  payout     Payout   @relation(fields: [payoutId], references: [id], onDelete: Cascade)
+
+  @@index([payoutId])
+  @@index([createdAt(sort: Desc)])
+}
+
 model Receipt {
   id            String      @id @default(cuid())
   transactionId String
@@ -710,6 +725,7 @@ model Payout {
   disputes             WithdrawalDispute[]
   blacklistEntries     PayoutBlacklist[]
   cancellationHistory  PayoutCancellationHistory[]
+  callbackHistory      PayoutCallbackHistory[]
 
   @@index([status, traderId])
   @@index([merchantId, status])

--- a/backend/src/routes/admin/payouts.ts
+++ b/backend/src/routes/admin/payouts.ts
@@ -963,4 +963,54 @@ export const adminPayoutsRoutes = new Elysia({ prefix: "/payouts" })
         metadata: t.Optional(t.Any()),
       }),
     },
+
+  // Manually send payout callback
+  .post(
+    '/:id/callback',
+    async ({ params, body, error }) => {
+      const payout = await db.payout.findUnique({ where: { id: params.id } });
+      if (!payout) return error(404, { error: 'Payout not found' });
+      if (!payout.merchantWebhookUrl)
+        return error(400, { error: 'Webhook URL not set for payout' });
+
+      const status = body.status || payout.status;
+      await payoutService.sendMerchantWebhook(payout, status);
+
+      const history = await db.payoutCallbackHistory.findFirst({
+        where: { payoutId: payout.id },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      return {
+        success: true,
+        callbackHistoryEntry: history
+          ? { ...history, createdAt: history.createdAt.toISOString() }
+          : null,
+      };
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      body: t.Object({ status: t.Optional(t.String()) }),
+    },
+  )
+
+  // Get payout callback history
+  .get(
+    '/:id/callbacks',
+    async ({ params, error }) => {
+      const payout = await db.payout.findUnique({
+        where: { id: params.id },
+        include: { callbackHistory: { orderBy: { createdAt: 'desc' } } },
+      });
+      if (!payout) return error(404, { error: 'Payout not found' });
+
+      return {
+        success: true,
+        callbackHistory: payout.callbackHistory.map((cb) => ({
+          ...cb,
+          createdAt: cb.createdAt.toISOString(),
+        })),
+      };
+    },
+    { params: t.Object({ id: t.String() }) },
   );

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -774,6 +774,14 @@ export const adminApi = {
     const response = await adminApiInstance.get('/admin/payouts', { params })
     return response.data
   },
+  sendPayoutCallback: async (payoutId: string, data?: { status?: string }) => {
+    const response = await adminApiInstance.post(`/admin/payouts/${payoutId}/callback`, data)
+    return response.data
+  },
+  getPayoutCallbackHistory: async (payoutId: string) => {
+    const response = await adminApiInstance.get(`/admin/payouts/${payoutId}/callbacks`)
+    return response.data
+  },
   approvePayout: async (payoutId: string) => {
     const response = await adminApiInstance.post(`/admin/payouts/${payoutId}/approve`)
     return response.data


### PR DESCRIPTION
## Summary
- add `PayoutCallbackHistory` model and relation
- record payout webhook callbacks and expose resend & history endpoints
- allow admin UI to resend payout callbacks and view webhook history

## Testing
- `npx prisma migrate dev --name add_payout_callback_history` *(failed: permission denied to create database)*
- `npx prisma generate`
- `npx prisma validate`
- `bun run typecheck` *(failed: Script not found "typecheck")*
- `bun test` *(tests failed)*
- `npm run build`
- `npm run type-check` *(failed: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6893588526908320a2813e20c01354d9