### PR TITLE
fix: import MethodType to prevent wellbit payment errors

### DIFF
--- a/backend/src/routes/wellbit/payment.ts
+++ b/backend/src/routes/wellbit/payment.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { BankType, PayoutStatus, Status, TransactionType } from '@prisma/client';
+import { BankType, PayoutStatus, Status, TransactionType, MethodType } from '@prisma/client';
 import { wellbitGuard } from '@/middleware/wellbitGuard';
 import { db } from '@/db';
 import { mapToWellbitStatus, mapFromWellbitStatusToTransaction } from '@/utils/wellbit-status-mapper';


### PR DESCRIPTION
## Summary
- fix Wellbit payment route by importing missing `MethodType`

## Testing
- `bun test tests/wellbit.test.ts --timeout 10000` (fails: Expected 200 Received 400)
- `bun run typecheck` (fails: Script not found "typecheck")
- `npx prisma validate`


------
https://chatgpt.com/codex/tasks/task_e_6893737ff358832087dfb294577f0010