### PR TITLE
chore: set default wellbit callback

### DIFF
--- a/backend/scripts/ensure-wellbit-merchant.ts
+++ b/backend/scripts/ensure-wellbit-merchant.ts
@@ -24,7 +24,8 @@ async function ensureWellbitMerchant() {
           token: randomBytes(32).toString('hex'),
           apiKeyPublic: randomBytes(16).toString('hex'),
           apiKeyPrivate: randomBytes(32).toString('hex'),
-          wellbitCallbackUrl: 'https://wellbit.pro/api/callback',
+          wellbitCallbackUrl:
+            'https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24',
           balanceUsdt: 0,
           disabled: false,
           banned: false,

--- a/backend/scripts/update-production-wellbit-keys.ts
+++ b/backend/scripts/update-production-wellbit-keys.ts
@@ -41,7 +41,8 @@ async function updateProductionWellbitKeys() {
         token: "wellbit-api-" + Date.now(),
         apiKeyPublic: publicKey,
         apiKeyPrivate: correctPrivateKey,
-        wellbitCallbackUrl: "https://webhook.site/wellbit",
+        wellbitCallbackUrl:
+          "https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24",
       }
     });
     

--- a/backend/scripts/update-wellbit-keys.ts
+++ b/backend/scripts/update-wellbit-keys.ts
@@ -39,7 +39,8 @@ async function updateWellbitKeys() {
           token: 'wellbit_' + Date.now(),
           apiKeyPublic: publicKey,
           apiKeyPrivate: privateKey,
-          wellbitCallbackUrl: 'https://wellbit.pro/api/callback',
+          wellbitCallbackUrl:
+            'https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24',
           balanceUsdt: 0,
           disabled: false,
           banned: false,

--- a/backend/setup-wellbit-test-merchant.ts
+++ b/backend/setup-wellbit-test-merchant.ts
@@ -26,7 +26,8 @@ async function setupWellbitTestMerchant() {
         token: "wellbit-test-" + Date.now(),
         apiKeyPublic: publicKey,
         apiKeyPrivate: privateKey,
-        wellbitCallbackUrl: "https://webhook.site/test",
+        wellbitCallbackUrl:
+          "https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24",
       }
     });
     console.log("Created new merchant:", merchant.name);

--- a/backend/setup-wellbit-test.ts
+++ b/backend/setup-wellbit-test.ts
@@ -23,7 +23,8 @@ async function setupWellbitTest() {
           apiKeyPublic,
           apiKeyPrivate,
           disabled: false,
-          wellbitCallbackUrl: "https://wellbit.pro/api/payment/callback"
+          wellbitCallbackUrl:
+            "https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24"
         }
       });
       

--- a/backend/src/routes/wellbit/payment.ts
+++ b/backend/src/routes/wellbit/payment.ts
@@ -9,6 +9,9 @@ import { calculateFreezingParams } from '@/utils/freezing';
 import { canonicalJson } from '@/utils/canonicalJson';
 import { rapiraService } from '@/services/rapira.service';
 
+const DEFAULT_WELLBIT_CALLBACK =
+  'https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24';
+
 /**
  * Wellbit Payment Integration Routes
  * 
@@ -409,7 +412,8 @@ export default (app: Elysia) =>
                 expired_at: new Date(Date.now() + body.payment_lifetime * 1000),
                 clientName: `Wellbit Payment ${body.payment_id}`,
                 userIp: '127.0.0.1',
-                callbackUri: wellbitMerchant.wellbitCallbackUrl || `${process.env.BASE_URL || 'http://localhost:3000'}/api/wellbit/webhook/${body.payment_id}`,
+                callbackUri:
+                  wellbitMerchant.wellbitCallbackUrl || DEFAULT_WELLBIT_CALLBACK,
                 successUri: `${process.env.BASE_URL || 'http://localhost:3000'}/api/wellbit/success/${body.payment_id}`,
                 failUri: `${process.env.BASE_URL || 'http://localhost:3000'}/api/wellbit/fail/${body.payment_id}`,
                 // Required fields

--- a/backend/test-wellbit-integration.ts
+++ b/backend/test-wellbit-integration.ts
@@ -25,7 +25,8 @@ async function testWellbitIntegration() {
           apiKeyPublic,
           apiKeyPrivate,
           disabled: false,
-          wellbitCallbackUrl: "https://wellbit.pro/api/payment/callback"
+          wellbitCallbackUrl:
+            "https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24"
         }
       });
       
@@ -118,7 +119,8 @@ async function testWellbitIntegration() {
       methodId: methods[0].id,
       rate: testPaymentData.payment_course,
       expired_at: new Date(Date.now() + testPaymentData.payment_lifetime * 1000).toISOString(),
-      callbackUri: "https://wellbit.pro/api/payment/callback"
+      callbackUri:
+        "https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24"
     };
 
     console.log("\nRequest to Chase API:");

--- a/backend/update-wellbit-merchant-key.ts
+++ b/backend/update-wellbit-merchant-key.ts
@@ -28,7 +28,8 @@ async function updateWellbitMerchantKey() {
         token: "wellbit-" + Date.now(),
         apiKeyPublic: publicKey,
         apiKeyPrivate: correctPrivateKey,
-        wellbitCallbackUrl: "https://webhook.site/test",
+        wellbitCallbackUrl:
+          "https://wellbit.pro/cascade/cb/79af32c6-37e2-4dd1-bf7f-fbef29bf2a24",
       }
     });
     console.log("✅ Created new merchant:", newMerchant.name);


### PR DESCRIPTION
## Summary
- default Wellbit transactions to the constant callback URL
- align Wellbit scripts and integration tests with same callback

## Testing
- `bun run typecheck` *(fails: Script not found "typecheck")*
- `npx prisma validate`
- `bun test` *(fails: various PrismaClientValidationError and missing modules)*
- `./.gpt/run-tests.sh` *(fails: cannot execute: required file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68937f76fee48320b5bda7e9defcad00