### PR TITLE
fix: prepare deployment dir before scp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,8 +81,20 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Copy installation script to server
+
+      - name: Prepare deployment directory
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          script: |
+            mkdir -p "${{ secrets.PROJECT_PATH }}"
+            rm -rf "${{ secrets.PROJECT_PATH }}"/* || true
+
+      - name: Copy repository to server
         uses: appleboy/scp-action@v0.1.5
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -92,7 +104,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           source: "."
           target: "${{ secrets.PROJECT_PATH }}"
-          rm: true
+          overwrite: true
       
       - name: Deploy to server
         uses: appleboy/ssh-action@v1.0.0


### PR DESCRIPTION
## Summary
- avoid scp step failing to remove target by preparing directory via ssh and enabling overwrite

## Testing
- `cd backend && bun run typecheck` *(fails: Script not found)*
- `cd backend && bunx tsc --noEmit` *(fails: TS6059 errors)*
- `cd backend && npx prisma validate`
- `cd backend && bun test` *(fails: bank-mapping and other tests)*
- `cd frontend && npm run type-check` *(fails: Missing script)*
- `cd frontend && npm run build` *(warnings; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689500e13c18832085c21093ab12a7f4