### PR TITLE
feat(admin): log deal creation attempts

### DIFF
--- a/backend/src/api/merchant/payouts.ts
+++ b/backend/src/api/merchant/payouts.ts
@@ -124,6 +124,15 @@ export const merchantPayoutsApi = new Elysia({ prefix: "/payouts" })
             wallet: payout.wallet,
             bank: payout.bank,
             isCard: payout.isCard,
+            method: payout.method
+              ? {
+                  id: payout.method.id,
+                  code: payout.method.code,
+                  name: payout.method.name,
+                  type: payout.method.type,
+                  currency: payout.method.currency,
+                }
+              : null,
             status: payout.status,
             expireAt: payout.expireAt,
             createdAt: payout.createdAt,

--- a/backend/src/constants/banks.ts
+++ b/backend/src/constants/banks.ts
@@ -1,4 +1,4 @@
-export const BANKS = [
+const BANKS_RAW = [
   {
     "code": "SBERBANK",
     "label": "Сбербанк"
@@ -819,4 +819,8 @@ export const BANKS = [
     "code": "UZUMBANK",
     "label": "UZUMBANK"
   }
-] as const;
+];
+
+export const BANKS = Array.from(
+  new Map(BANKS_RAW.map((b) => [b.label, b])).values(),
+) as typeof BANKS_RAW;

--- a/backend/src/routes/merchant/index.ts
+++ b/backend/src/routes/merchant/index.ts
@@ -624,6 +624,17 @@ export default (app: Elysia) =>
         }
 
         if (!chosen) {
+          await db.transactionAttempt.create({
+            data: {
+              merchantId: merchant.id,
+              methodId: method.id,
+              amount: body.amount,
+              success: false,
+              status: 'NO_REQUISITE',
+              errorCode: 'NO_REQUISITE',
+              message: 'Не найден подходящий реквизит'
+            }
+          });
           return error(409, { error: "NO_REQUISITE" });
         }
 
@@ -709,6 +720,17 @@ export default (app: Elysia) =>
             console.log(
               `[Merchant IN] Недостаточно баланса. Нужно: ${freezingParams.totalRequired}, доступно: ${availableBalance}`,
             );
+            await db.transactionAttempt.create({
+              data: {
+                merchantId: merchant.id,
+                methodId: method.id,
+                amount: body.amount,
+                success: false,
+                status: 'NO_REQUISITE',
+                errorCode: 'INSUFFICIENT_BALANCE',
+                message: 'Недостаточно баланса трейдера'
+              }
+            });
             return error(409, { error: "NO_REQUISITE" });
           }
         }
@@ -797,6 +819,16 @@ export default (app: Elysia) =>
           }
 
           return transaction;
+        });
+        await db.transactionAttempt.create({
+          data: {
+            transactionId: tx.id,
+            merchantId: merchant.id,
+            methodId: method.id,
+            amount: tx.amount,
+            success: true,
+            status: tx.status
+          }
         });
 
         const crypto =

--- a/backend/src/tests/merchant-payout-api.test.ts
+++ b/backend/src/tests/merchant-payout-api.test.ts
@@ -12,12 +12,16 @@ describe("Merchant Payout API Tests", () => {
   let merchant: any;
   let trader: any;
   let apiKey: string;
+  let method: any;
   
   beforeAll(async () => {
     await cleanupTestData();
     merchant = await createTestMerchant();
     trader = await createTestTrader();
     apiKey = merchant.token;
+    method = await db.method.findFirst({
+      where: { merchantMethods: { some: { merchantId: merchant.id } } },
+    });
     
     // Create test app with the API
     app = new Elysia()
@@ -42,6 +46,7 @@ describe("Merchant Payout API Tests", () => {
             wallet: "41001234567890",
             bank: "SBER",
             isCard: true,
+            methodId: method.id,
             merchantRate: 100,
             externalReference: "API-TEST-001",
             webhookUrl: "https://example.com/webhook",
@@ -72,6 +77,7 @@ describe("Merchant Payout API Tests", () => {
             wallet: "41001234567890",
             bank: "SBER",
             isCard: true,
+            methodId: method.id,
             merchantRate: 100,
           }),
         })
@@ -95,6 +101,7 @@ describe("Merchant Payout API Tests", () => {
             wallet: "41001234567890",
             bank: "SBER",
             isCard: true,
+            methodId: method.id,
             merchantRate: 100,
           }),
         })
@@ -112,6 +119,7 @@ describe("Merchant Payout API Tests", () => {
         wallet: "41001234567890",
         bank: "SBER",
         isCard: true,
+        methodId: method.id,
         merchantRate: 100,
       });
       
@@ -139,6 +147,7 @@ describe("Merchant Payout API Tests", () => {
         wallet: "41001234567890",
         bank: "SBER",
         isCard: true,
+        methodId: method.id,
         merchantRate: 100,
       });
       

--- a/frontend/constants/banks.ts
+++ b/frontend/constants/banks.ts
@@ -1,4 +1,4 @@
-export const BANKS = [
+const BANKS_RAW = [
   {
     "code": "SBERBANK",
     "label": "Сбербанк"
@@ -819,5 +819,10 @@ export const BANKS = [
     "code": "UZUMBANK",
     "label": "UZUMBANK"
   }
-] as const;
-export type BankCode = typeof BANKS[number]["code"];
+];
+
+export const BANKS = Array.from(
+  new Map(BANKS_RAW.map((b) => [b.label, b])).values(),
+) as typeof BANKS_RAW;
+
+export type BankCode = typeof BANKS_RAW[number]["code"];

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -825,6 +825,10 @@ export const adminApi = {
     const response = await adminApiInstance.get(`/admin/transactions/${id}`)
     return response.data
   },
+  getTransactionAttempts: async (params?: any) => {
+    const response = await adminApiInstance.get('/admin/transactions/attempts', { params })
+    return response.data
+  },
   updateTransactionStatus: async (id: string, status: string) => {
     const response = await adminApiInstance.patch(`/admin/transactions/${id}/status`, { status })
     return response.data


### PR DESCRIPTION
## Summary
- dedupe bank constants so merchant bank list contains unique entries
- persist and expose payout method when merchants create payouts
- ensure merchant payout API tests include method id

## Testing
- `./.gpt/check-status.sh` *(failed: No such file or directory)*
- `cd backend && bun test` *(failed: Unknown field `dailyLimit` for select statement on model `BankDetail`)*
- `cd backend && bun run typecheck` *(failed: Script not found "typecheck")*
- `cd backend && npx prisma validate`
- `cd frontend && npm run build`
- `cd frontend && npm run type-check` *(failed: Missing script "type-check")*


------
https://chatgpt.com/codex/tasks/task_e_6895ffe4b9088320bcb59243274f31ad