### PR TITLE
feat(admin): log deal creation attempts

### DIFF
--- a/backend/src/api/merchant/payouts.ts
+++ b/backend/src/api/merchant/payouts.ts
@@ -124,6 +124,15 @@ export const merchantPayoutsApi = new Elysia({ prefix: "/payouts" })
             wallet: payout.wallet,
             bank: payout.bank,
             isCard: payout.isCard,
+            method: payout.method
+              ? {
+                  id: payout.method.id,
+                  code: payout.method.code,
+                  name: payout.method.name,
+                  type: payout.method.type,
+                  currency: payout.method.currency,
+                }
+              : null,
             status: payout.status,
             expireAt: payout.expireAt,
             createdAt: payout.createdAt,

--- a/backend/src/constants/banks.ts
+++ b/backend/src/constants/banks.ts
@@ -1,4 +1,4 @@
-export const BANKS = [
+const BANKS_RAW = [
   {
     "code": "SBERBANK",
     "label": "Сбербанк"
@@ -819,4 +819,8 @@ export const BANKS = [
     "code": "UZUMBANK",
     "label": "UZUMBANK"
   }
-] as const;
+];
+
+export const BANKS = Array.from(
+  new Map(BANKS_RAW.map((b) => [b.label, b])).values(),
+) as typeof BANKS_RAW;

--- a/backend/src/routes/admin/transactions.ts
+++ b/backend/src/routes/admin/transactions.ts
@@ -140,6 +140,103 @@ const AuthHeaderSchema = t.Object({ 'x-admin-key': t.String() })
 
 export default (app: Elysia) =>
   app
+    /* ─────────── GET /admin/transactions/attempts ─────────── */
+    .get(
+      '/attempts',
+      async ({ query }) => {
+        const page = Number(query.page) || 1;
+        const limit = Number(query.limit) || 20;
+        const skip = (page - 1) * limit;
+
+        const [attempts, total] = await db.$transaction([
+          db.transactionAttempt.findMany({
+            orderBy: { createdAt: 'desc' },
+            skip,
+            take: limit,
+            include: {
+              merchant: { select: { id: true, name: true } },
+              method: { select: { id: true, name: true } }
+            }
+          }),
+          db.transactionAttempt.count()
+        ]);
+
+        const transactionMap = attempts.length
+          ? await db.transaction
+              .findMany({
+                where: {
+                  id: {
+                    in: attempts
+                      .filter(a => a.transactionId)
+                      .map(a => a.transactionId!)
+                  }
+                },
+                select: { id: true, numericId: true }
+              })
+              .then(trxs => trxs.reduce((acc, t) => ({ ...acc, [t.id]: t.numericId }), {}))
+          : {};
+
+        return {
+          data: attempts.map(a => ({
+            id: a.id,
+            transactionId: a.transactionId,
+            transactionNumericId: a.transactionId ? transactionMap[a.transactionId] ?? null : null,
+            merchantId: a.merchantId,
+            merchantName: a.merchant?.name ?? null,
+            methodId: a.methodId,
+            methodName: a.method?.name ?? null,
+            amount: a.amount,
+            success: a.success,
+            status: a.status,
+            errorCode: a.errorCode,
+            message: a.message,
+            createdAt: a.createdAt.toISOString()
+          })),
+          pagination: {
+            page,
+            limit,
+            total,
+            totalPages: Math.ceil(total / limit)
+          }
+        };
+      },
+      {
+        tags: ['admin'],
+        detail: { summary: 'Список запросов на создание сделок' },
+        headers: AuthHeaderSchema,
+        query: t.Object({
+          page: t.Optional(t.String()),
+          limit: t.Optional(t.String())
+        }),
+        response: {
+          200: t.Object({
+            data: t.Array(
+              t.Object({
+                id: t.String(),
+                transactionId: t.Union([t.String(), t.Null()]),
+                transactionNumericId: t.Union([t.Number(), t.Null()]),
+                merchantId: t.String(),
+                merchantName: t.Union([t.String(), t.Null()]),
+                methodId: t.String(),
+                methodName: t.Union([t.String(), t.Null()]),
+                amount: t.Number(),
+                success: t.Boolean(),
+                status: t.Union([t.String(), t.Null()]),
+                errorCode: t.Union([t.String(), t.Null()]),
+                message: t.Union([t.String(), t.Null()]),
+                createdAt: t.String()
+              })
+            ),
+            pagination: t.Object({
+              page: t.Number(),
+              limit: t.Number(),
+              total: t.Number(),
+              totalPages: t.Number()
+            })
+          })
+        }
+      }
+    )
     /* ─────────── POST /admin/transactions/create ─────────── */
     .post(
       '/create',

--- a/backend/src/routes/merchant/index.ts
+++ b/backend/src/routes/merchant/index.ts
@@ -624,6 +624,17 @@ export default (app: Elysia) =>
         }
 
         if (!chosen) {
+          await db.transactionAttempt.create({
+            data: {
+              merchantId: merchant.id,
+              methodId: method.id,
+              amount: body.amount,
+              success: false,
+              status: 'NO_REQUISITE',
+              errorCode: 'NO_REQUISITE',
+              message: 'Не найден подходящий реквизит'
+            }
+          });
           return error(409, { error: "NO_REQUISITE" });
         }
 
@@ -709,6 +720,17 @@ export default (app: Elysia) =>
             console.log(
               `[Merchant IN] Недостаточно баланса. Нужно: ${freezingParams.totalRequired}, доступно: ${availableBalance}`,
             );
+            await db.transactionAttempt.create({
+              data: {
+                merchantId: merchant.id,
+                methodId: method.id,
+                amount: body.amount,
+                success: false,
+                status: 'NO_REQUISITE',
+                errorCode: 'INSUFFICIENT_BALANCE',
+                message: 'Недостаточно баланса трейдера'
+              }
+            });
             return error(409, { error: "NO_REQUISITE" });
           }
         }
@@ -797,6 +819,16 @@ export default (app: Elysia) =>
           }
 
           return transaction;
+        });
+        await db.transactionAttempt.create({
+          data: {
+            transactionId: tx.id,
+            merchantId: merchant.id,
+            methodId: method.id,
+            amount: tx.amount,
+            success: true,
+            status: tx.status
+          }
         });
 
         const crypto =

--- a/backend/src/tests/merchant-payout-api.test.ts
+++ b/backend/src/tests/merchant-payout-api.test.ts
@@ -12,12 +12,16 @@ describe("Merchant Payout API Tests", () => {
   let merchant: any;
   let trader: any;
   let apiKey: string;
+  let method: any;
   
   beforeAll(async () => {
     await cleanupTestData();
     merchant = await createTestMerchant();
     trader = await createTestTrader();
     apiKey = merchant.token;
+    method = await db.method.findFirst({
+      where: { merchantMethods: { some: { merchantId: merchant.id } } },
+    });
     
     // Create test app with the API
     app = new Elysia()
@@ -42,6 +46,7 @@ describe("Merchant Payout API Tests", () => {
             wallet: "41001234567890",
             bank: "SBER",
             isCard: true,
+            methodId: method.id,
             merchantRate: 100,
             externalReference: "API-TEST-001",
             webhookUrl: "https://example.com/webhook",
@@ -72,6 +77,7 @@ describe("Merchant Payout API Tests", () => {
             wallet: "41001234567890",
             bank: "SBER",
             isCard: true,
+            methodId: method.id,
             merchantRate: 100,
           }),
         })
@@ -95,6 +101,7 @@ describe("Merchant Payout API Tests", () => {
             wallet: "41001234567890",
             bank: "SBER",
             isCard: true,
+            methodId: method.id,
             merchantRate: 100,
           }),
         })
@@ -112,6 +119,7 @@ describe("Merchant Payout API Tests", () => {
         wallet: "41001234567890",
         bank: "SBER",
         isCard: true,
+        methodId: method.id,
         merchantRate: 100,
       });
       
@@ -139,6 +147,7 @@ describe("Merchant Payout API Tests", () => {
         wallet: "41001234567890",
         bank: "SBER",
         isCard: true,
+        methodId: method.id,
         merchantRate: 100,
       });
       

--- a/frontend/app/trader/requisites/page.tsx
+++ b/frontend/app/trader/requisites/page.tsx
@@ -151,7 +151,6 @@ export default function TraderRequisitesPage() {
       console.log('[Requisites] Raw data from API:', data);
       // Ensure data is an array
       const dataArray = Array.isArray(data) ? data : [];
-      // Add mock data for successful deals if not present
       const requisitesWithDeals = dataArray.map((req: any) => {
         console.log('[Requisites] Processing requisite:', req?.id, {
           currentTotalAmount: req?.currentTotalAmount,
@@ -171,17 +170,17 @@ export default function TraderRequisitesPage() {
           cardNumber: req?.cardNumber || '',
           recipientName: req?.recipientName || '',
           phoneNumber: req?.phoneNumber || '',
-          minAmount: req?.minAmount || 0,
-          maxAmount: req?.maxAmount || 0,
-          currentTotalAmount: req?.currentTotalAmount || 0,
-          operationLimit: req?.operationLimit || 0,
-          sumLimit: req?.sumLimit || 0,
-          activeDeals: req?.activeDeals || 0,
+          minAmount: Number(req?.minAmount ?? 0),
+          maxAmount: Number(req?.maxAmount ?? 0),
+          currentTotalAmount: Number(req?.currentTotalAmount ?? 0),
+          operationLimit: Number(req?.operationLimit ?? 0),
+          sumLimit: Number(req?.sumLimit ?? 0),
+          activeDeals: Number(req?.activeDeals ?? 0),
           intervalMinutes: req?.intervalMinutes || 0,
           turnoverDay: req?.turnoverDay || 0,
           turnoverTotal: req?.turnoverTotal || 0,
-          successfulDeals: req?.successfulDeals || 0,
-          totalDeals: req?.totalDeals || 0,
+          successfulDeals: Number(req?.successfulDeals ?? 0),
+          totalDeals: Number(req?.totalDeals ?? 0),
           isArchived: req?.isArchived || false,
           isActive: req?.isActive !== undefined ? req?.isActive : true,
           hasDevice: req?.hasDevice || false,

--- a/frontend/components/merchant/payouts-list.tsx
+++ b/frontend/components/merchant/payouts-list.tsx
@@ -221,7 +221,9 @@ export function PayoutsList({ filters }: PayoutsListProps) {
                   )}
                 </TableCell>
                 <TableCell className="text-red-600">
-                  {payout.feePercent ? `-${payout.feePercent.toFixed(2)}%` : '—'}
+                  {typeof payout.payoutsCommission === 'number'
+                    ? `-${formatAmount(payout.payoutsCommission)} ₽`
+                    : '—'}
                 </TableCell>
                 <TableCell>
                   {payout.method ? (

--- a/frontend/constants/banks.ts
+++ b/frontend/constants/banks.ts
@@ -1,4 +1,4 @@
-export const BANKS = [
+const BANKS_RAW = [
   {
     "code": "SBERBANK",
     "label": "Сбербанк"
@@ -819,5 +819,10 @@ export const BANKS = [
     "code": "UZUMBANK",
     "label": "UZUMBANK"
   }
-] as const;
-export type BankCode = typeof BANKS[number]["code"];
+];
+
+export const BANKS = Array.from(
+  new Map(BANKS_RAW.map((b) => [b.label, b])).values(),
+) as typeof BANKS_RAW;
+
+export type BankCode = typeof BANKS_RAW[number]["code"];

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -825,6 +825,10 @@ export const adminApi = {
     const response = await adminApiInstance.get(`/admin/transactions/${id}`)
     return response.data
   },
+  getTransactionAttempts: async (params?: any) => {
+    const response = await adminApiInstance.get('/admin/transactions/attempts', { params })
+    return response.data
+  },
   updateTransactionStatus: async (id: string, status: string) => {
     const response = await adminApiInstance.patch(`/admin/transactions/${id}/status`, { status })
     return response.data


### PR DESCRIPTION
## Summary
- dedupe bank constants so merchant bank list contains unique entries
- persist and expose payout method when merchants create payouts
- ensure merchant payout API tests include method id
- show payout commission in merchant payouts list
- log merchant deal creation attempts for admin review
- fix admin transaction attempts query and show real trader deal stats

## Testing
- `./.gpt/check-status.sh` *(failed: Password for user -d)*
- `cd backend && bun test` *(failed: PrismaClientValidationError: Unknown argument `dailyLimit` for select statement on model `BankDetail`)*
- `cd backend && bun run typecheck` *(failed: Script not found "typecheck")*
- `cd backend && npx prisma validate`
- `cd frontend && npm run build`
- `cd frontend && npm run type-check` *(failed: Missing script "type-check")*
- `./.gpt/test-frontend-page.sh /trader/requisites` *(failed: cannot execute; required file not found)*
- `./.gpt/test-endpoint.sh GET /api/admin/transactions/attempts?limit=20&page=1` *(failed: cannot execute; required file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895ffe4b9088320bcb59243274f31ad