### PR TITLE
Show time in admin deals requests

### DIFF
--- a/frontend/app/admin/deals/page.tsx
+++ b/frontend/app/admin/deals/page.tsx
@@ -15,7 +15,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Di
 import { toast } from 'sonner'
 import { adminApi as api } from '@/services/api'
 import { useAdminAuth } from '@/stores/auth'
-import { formatAmount, formatDate } from '@/lib/utils'
+import { formatAmount, formatDate, formatDateTime } from '@/lib/utils'
 import { 
   CreditCard, 
   Search, 
@@ -801,7 +801,7 @@ export default function AdminDealsPage() {
           <TableBody>
             {attempts.map(a => (
               <TableRow key={a.id}>
-                <TableCell>{formatDate(a.createdAt)}</TableCell>
+                <TableCell>{formatDateTime(a.createdAt)}</TableCell>
                 <TableCell>{a.merchantName || a.merchantId}</TableCell>
                 <TableCell>{a.methodName || a.methodId}</TableCell>
                 <TableCell>{formatAmount(a.amount)} ₽</TableCell>


### PR DESCRIPTION
## Summary
- show time alongside dates for admin deal requests

## Testing
- `bun run typecheck` *(fails: Script not found "typecheck")*
- `npx prisma validate`
- `bun test` *(fails: PrismaClientValidationError)*
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build` *(partial: started Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68965efb4bf48320a9c9d56959b2bd11