### PR TITLE
feat: add admin deal filters and balance period selection

### DIFF
--- a/frontend/app/(merchant)/merchant/page.tsx
+++ b/frontend/app/(merchant)/merchant/page.tsx
@@ -310,9 +310,12 @@ export default function MerchantDashboardPage() {
               <SelectValue placeholder="Выберите период" />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="24h">24 часа</SelectItem>
               <SelectItem value="today">Сегодня</SelectItem>
+              <SelectItem value="yesterday">Вчера</SelectItem>
               <SelectItem value="week">Неделя</SelectItem>
               <SelectItem value="month">Месяц</SelectItem>
+              <SelectItem value="year">Год</SelectItem>
               <SelectItem value="all">Весь период</SelectItem>
             </SelectContent>
           </Select>


### PR DESCRIPTION
## Summary
- add amount, payment method, method type, and merchant filters to admin deals
- display deal time alongside date
- allow merchants and admins to view balance metrics for custom periods like 24h, today, yesterday, week, month, year, or all time

## Testing
- `npm run type-check` *(fails: Missing script)*
- `npm run build`
- `bun run typecheck` *(fails: Script not found)*
- `bun test` *(fails: PrismaClientValidationError)*
- `npx prisma validate`

------
https://chatgpt.com/codex/tasks/task_e_6896778b8d448320a2930057fab9d2a5